### PR TITLE
Contributors: make GitHub username and GitHub repo configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: scala
 scala:
-- 2.10.2
+- 2.11.1
 branches:
   only:
-    - master
-    - develop
+  - master
+  - develop
 deploy:
   provider: heroku
   api_key:
@@ -12,7 +12,9 @@ deploy:
   app:
     master: scala-vienna-prod
     develop: scala-vienna-dev
-MEETUP_API_KEY:
-  secure: qUTGe1d/hdYGtAq/H/oWpYmSf3wUvME6wopDTlMQaOUIrnUEtwHVbZ/w6W1bgjYwJLDH4o9pyn5lw25ICM+tWyj7ChldAlOGDWYp8P14UP/6MZyogL2psHc7aKbXncRd6WTlGHr8kYamxGDsCUuFYcVqRIQXmZSv4o0rw8Yn5e8=
-GITHUB_API_KEY:
-  secure: TGg7eioNdIZ/ccWHMlbSuo1qOswoYlcDE9h8HSVLyHEEFvGVYuFCs1NHgJLP+6uT95RgVWkBE1fIE7aEQ/m2JPB4i8VrON7OjIXSHHrbgLRMWc3ECrNWX8uAu/BG9FaAHNUKvvBpvi+jy8Ckxd9R7g5pfR9jZ04x9wdMl5FAyGI=
+# Encripted env vars: MEETUP_API_KEY, GITHUB_AUTH_CLIENT_ID, GITHUB_AUTH_CLIENT_SECRET
+env:
+  global:
+  - secure: PCx4ucdd4FpPaoJ/n7xPtKpNWnefHzFezYjZ1CqmPSMSj2F9JoZO8n1GlrP4sH4I+SLzvPvUXhwaHGY7k2nIgb6596ny+G3uDcWPBTPzSxqPL3uCd0iD64PdnI+q3i724XQFfBqusVREBHB64NXPDK6t1F7PdIW3dO2ci19QV/Q=
+  - secure: dGDgsvCiFSh9h1DUtRLlcofP3e3VRQP+MLTC5avirWJ5ZUAxkaw1ZxM75tgP2JPwz+Y6iqi+jdtUGEWj8YaeeNkMpiuPrS2XpSBM2WvzLKCXxgHplGHoI4bFNA1Sxoyb+CEqaHXKdoJWnQdRoWn7dbDqc33R20Hi2IulMWMZwZg=
+  - secure: NAXYgBGPUJsuB7HkW8BhdZuCHCkglPfKS7pK5pz8u5IOGrMKk9Ws/HFAODPBg1xEt83RRanaQRt/nY1VWCO4J+4NCwVRP9SIeQJk8+i7h1zz3K7E24b9SpAig/yzGGhgc87kqSUnKYxEwFQefdCC0izZYNyoUapbZRo95GqfYnc=

--- a/README.md
+++ b/README.md
@@ -15,12 +15,15 @@ This is the [Play](http://www.playframework.com) application that powers the web
 - Grab and install [Play](http://www.playframework.com)
 - Install the [Chrome tools](https://chrome.google.com/webstore/detail/play-framework-tools/dchhggpgbommpcjpogaploblnpldbmen) to get the auto-reloading benefits
 - Check your meetup.com API key here http://www.meetup.com/meetup_api/key/
-- Create a "Personal Access Token" for the app on your GitHub account: https://github.com/settings/applications
-- Create the following environment variables:
+- Configure the Meetup API authentication (see [Getting a Meetup API Key](https://secure.meetup.com/meetup_api/key/)):
   - `export MEETUP_API_KEY=<your API key>`
-  - `export GITHUB_API_KEY=<your GITHUB application access token>`
 - Optional: configure a different Meetup group ID in the meetup.groupId key in the application.conf file
-- Run Play with `play ~ run` to enable continuous reloading during development
+- Configure GitHub API authentication. It you are part of the [Scala Vienna GitHub organization](https://github.com/scala-vienna) you will be able to access 
+the `client` id and the `client secret` keys in the ["Applications" section](https://github.com/organizations/scala-vienna/settings/applications/119475). 
+Otherwise asks us to be added or generate your own keys.
+  - `export GITHUB_AUTH_CLIENT_ID=<the GitHub application client id>`
+  - `export GITHUB_AUTH_CLIENT_SECRET=<the GitHub application secret>`
+- Use `activator` to start the app
 
 ## Deployment
 

--- a/app/service/Github.scala
+++ b/app/service/Github.scala
@@ -81,13 +81,18 @@ object Github {
     created_at: Option[Date],
     updated_at: Option[Date])
 
-  val apiKey = Play.configuration.getString("github.apiKey").getOrElse(scala.util.Properties.envOrElse("GITHUB_API_KEY", ""))
+  val githubRepo = Play.configuration.getString("github.repo").getOrElse("")
+  val githubAuthClientId = Play.configuration.getString("github.auth.clientId").getOrElse("")
+  val githubAuthClientSecret = Play.configuration.getString("github.auth.clientSecret").getOrElse("")
 
   implicit val contributorFormat = Json.format[Contributor]
 
   def getContributors: Future[List[Contributor]] = {
-    WS.url("https://api.github.com/repos/rafacm/scala-vienna-web/contributors")
-      .withAuth(apiKey, "x-oauth-basic", WSAuthScheme.BASIC)
+    Logger.debug("githubRepo: ", githubRepo);
+    Logger.warn("githubAuthClientId: ", githubAuthClientId);
+    Logger.warn("githubAuthClientSecret: ", githubAuthClientSecret);
+
+    WS.url(s"https://api.github.com/repos/${githubRepo}/contributors?client_id=${githubAuthClientId}&client_secret=${githubAuthClientSecret}")
       .get().map(response =>
         if (response.status == 200) {
           response.json.validate[List[Contributor]]
@@ -100,7 +105,6 @@ object Github {
 
   def getUser(url: String): Future[Option[User]] = {
     WS.url(url)
-      .withAuth(apiKey, "x-oauth-basic", WSAuthScheme.BASIC)
       .get().map(response =>
         if (response.status == 200) {
           response.json.validate[User].map({ case user => Some(user) })

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -64,6 +64,12 @@ logger.application=DEBUG
 # Your meetup group id
 meetup.groupId= 5700242
 
+# The name of the GitHub repo in the format scala-vienna/scala-vienna-web
+# We use it to fetch the contributors to the app
+github.repo = "scala-vienna/scala-vienna-web"
+github.auth.clientId =  ${GITHUB_AUTH_CLIENT_ID}
+github.auth.clientSecret = ${GITHUB_AUTH_CLIENT_SECRET}
+
 # Blogs
 blogs.default.categories = ["scala", "akka", "play", "reactive"]
 


### PR DESCRIPTION
- Externalize GitHub repo and authentcaiont to application.conf
- Refactor authenticated GitHub API access since personal access tokens are not supported for organizations
- Configure OAuth client id and client secret in Travis CI config file
- Update README file with new needed GitHub authentication environment variables

Closes #34 
